### PR TITLE
ethwalinfo

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.21.1
+        go-version: 1.22
 
     - name: Test
       run: go test -v ./...

--- a/cmd/ethwalinfo/ethwalinfo.go
+++ b/cmd/ethwalinfo/ethwalinfo.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"cmp"
+	"fmt"
+	"os"
+
+	"github.com/0xsequence/ethwal"
+	"github.com/0xsequence/ethwal/storage"
+	"github.com/0xsequence/ethwal/storage/gcloud"
+	"github.com/0xsequence/ethwal/storage/local"
+	"github.com/urfave/cli/v2"
+)
+
+var DatasetPathFlag = &cli.StringFlag{
+	Name:     "path",
+	Usage:    "path to read",
+	Required: true,
+}
+
+var DatasetNameFlag = &cli.StringFlag{
+	Name:  "name",
+	Usage: "name of the dataset",
+	Value: "",
+}
+
+var DatasetVersion = &cli.StringFlag{
+	Name:  "version",
+	Usage: "version of the dataset",
+	Value: "",
+}
+
+var GoogleCloudBucket = &cli.StringFlag{
+	Name:  "google-cloud-bucket",
+	Usage: "google cloud bucket",
+}
+
+func main() {
+	app := cli.App{
+		Name:  "ethwalinfo",
+		Usage: "tool to view ethwal",
+		Flags: []cli.Flag{
+			DatasetPathFlag,
+			DatasetNameFlag,
+			DatasetVersion,
+			GoogleCloudBucket,
+		},
+		Action: func(c *cli.Context) error {
+			var fs storage.FS = local.NewLocalFS("./")
+			if bucket := c.String(GoogleCloudBucket.Name); bucket != "" {
+				fs = gcloud.NewGCloudFS(bucket, nil)
+			}
+
+			dataset := ethwal.Dataset{
+				Name:    c.String(DatasetNameFlag.Name),
+				Version: c.String(DatasetVersion.Name),
+				Path:    c.String(DatasetPathFlag.Name),
+			}
+
+			// mount fs to dataset path
+			fs = storage.NewPrefixWrapper(fs, dataset.FullPath())
+
+			walFiles, err := ethwal.ListWALFiles(fs)
+			if err != nil {
+				return err
+			}
+
+			fmt.Println("Dataset:", cmp.Or(dataset.Name, "-"))
+			fmt.Println("Version:", cmp.Or(dataset.Version, "-"))
+			if c.String(GoogleCloudBucket.Name) != "" {
+				fmt.Println("Filesystem:", "Google Cloud")
+				fmt.Println("Bucket:", c.String(GoogleCloudBucket.Name))
+			} else {
+				fmt.Println("Filesystem: local")
+			}
+			fmt.Println("Path:", dataset.Path)
+			fmt.Println("Number of files:", len(walFiles))
+			fmt.Println("Block range:", walFiles[0].FirstBlockNum, "-", walFiles[len(walFiles)-1].LastBlockNum)
+
+			return nil
+		},
+	}
+
+	if err := app.Run(os.Args); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "error: %s\n", err.Error())
+	}
+}

--- a/common.go
+++ b/common.go
@@ -13,7 +13,7 @@ import (
 	"github.com/0xsequence/ethwal/storage/local"
 )
 
-type walFile struct {
+type WALFile struct {
 	Name          string
 	FirstBlockNum uint64
 	LastBlockNum  uint64
@@ -24,6 +24,14 @@ type Dataset struct {
 	Version   string
 	Path      string
 	CachePath string
+}
+
+func (d Dataset) FullPath() string {
+	return buildETHWALPath(d.Name, d.Version, d.Path)
+}
+
+func (d Dataset) FullCachePath() string {
+	return buildETHWALPath(d.Name, d.Version, d.CachePath)
 }
 
 type Options struct {
@@ -86,8 +94,8 @@ func buildETHWALPath(name, version, walPath string) string {
 	return path.Join(walPath, name, version)
 }
 
-// parseWALFileBlockRange reads first and last block number stored in WAL file from file name
-func parseWALFileBlockRange(filePath string) (uint64, uint64) {
+// ParseWALFileBlockRange reads first and last block number stored in WAL file from file name
+func ParseWALFileBlockRange(filePath string) (uint64, uint64) {
 	_, fileName := path.Split(filePath)
 	fileNameSplit := strings.Split(fileName, ".")
 	blockNumberSplit := strings.Split(fileNameSplit[0], "_")
@@ -98,14 +106,14 @@ func parseWALFileBlockRange(filePath string) (uint64, uint64) {
 	return uint64(first), uint64(last)
 }
 
-// listWALFiles lists all WAL files in the provided file system
-func listWALFiles(fs storage.FS) ([]walFile, error) {
+// ListWALFiles lists all WAL files in the provided file system
+func ListWALFiles(fs storage.FS) ([]WALFile, error) {
 	wlk, ok := fs.(storage.Walker)
 	if !ok {
 		return nil, fmt.Errorf("ethlogwal: provided file system does not implement Walker interface")
 	}
 
-	var walFiles []walFile
+	var walFiles []WALFile
 	err := wlk.Walk(context.Background(), "", func(filePath string) error {
 		// walk only wal files
 		if path.Ext(filePath) != ".wal" {
@@ -113,8 +121,8 @@ func listWALFiles(fs storage.FS) ([]walFile, error) {
 		}
 
 		_, fileName := path.Split(filePath)
-		firstBlockNum, lastBlockNum := parseWALFileBlockRange(fileName)
-		walFiles = append(walFiles, walFile{
+		firstBlockNum, lastBlockNum := ParseWALFileBlockRange(fileName)
+		walFiles = append(walFiles, WALFile{
 			Name:          fileName,
 			FirstBlockNum: firstBlockNum,
 			LastBlockNum:  lastBlockNum,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/0xsequence/ethwal
 
-go 1.21.5
+go 1.22
 
 require (
 	cloud.google.com/go/storage v1.41.0

--- a/reader.go
+++ b/reader.go
@@ -33,7 +33,7 @@ type reader[T any] struct {
 
 	closer io.Closer
 
-	walFiles       []walFile
+	walFiles       []WALFile
 	currentWALFile int
 
 	lastBlockNum uint64
@@ -84,7 +84,7 @@ func NewReader[T any](opt Options) (Reader[T], error) {
 	// add prefix to file system
 	fs = storage.NewPrefixWrapper(fs, walPath)
 
-	walFiles, err := listWALFiles(fs)
+	walFiles, err := ListWALFiles(fs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load WAL file list: %w", err)
 	}

--- a/writer.go
+++ b/writer.go
@@ -69,7 +69,7 @@ func NewWriter[T any](opt Options) (Writer[T], error) {
 	// mount FS with WAL path prefix
 	fs := storage.NewPrefixWrapper(opt.FileSystem, walPath)
 
-	walFiles, err := listWALFiles(fs)
+	walFiles, err := ListWALFiles(fs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load WAL file list: %w", err)
 	}


### PR DESCRIPTION
```fish
⋊> ~/P/h/0/ethwal on ethwalinfo ⨯ ./ethwalinfo --google-cloud-bucket=sequence-dev-cluster-indexer-wal --name ethlog --version v1 --path=./ethwal/polygon/
Dataset: ethlog
Version: v1
Filesystem: Google Cloud
Bucket: sequence-dev-cluster-indexer-wal
Path: ./ethwal/polygon/
Number of files: 27321
Block range: 1 - 59384489

```