### PR TITLE
fix: first block num

### DIFF
--- a/common.go
+++ b/common.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path"
 	"sort"
@@ -21,6 +22,8 @@ import (
 	"github.com/0xsequence/ethwal/storage/local"
 	"github.com/c2h5oh/datasize"
 )
+
+const NoBlockNum = uint64(math.MaxUint64)
 
 type Dataset struct {
 	Name      string

--- a/filter.go
+++ b/filter.go
@@ -43,8 +43,6 @@ func (o FilterBuilderOptions[T]) WithDefaults() FilterBuilderOptions[T] {
 }
 
 type filterBuilder[T any] struct {
-	ctx context.Context
-
 	indexes map[IndexName]Index[T]
 	fs      storage.FS
 }

--- a/filter_test.go
+++ b/filter_test.go
@@ -58,7 +58,7 @@ func generateMixedIntBlocks() []Block[[]int] {
 	// 45-49 generate 5 blocks with no data
 	// 50-69 generate 20 blocks with random but repeating huge numbers
 
-	for i := 1; i <= 20; i++ {
+	for i := 0; i <= 20; i++ {
 		blocks = append(blocks, Block[[]int]{
 			Hash:   common.BytesToHash([]byte{byte(i)}),
 			Number: uint64(i),
@@ -288,7 +288,7 @@ func TestIntMixFiltering(t *testing.T) {
 	}
 
 	onlyEvenResults := onlyEvenFilter.IndexIterator(context.Background())
-	assert.Len(t, onlyEvenResults.Bitmap().ToArray(), 20)
+	assert.Len(t, onlyEvenResults.Bitmap().ToArray(), 21)
 	for _, block := range onlyEvenResults.Bitmap().ToArray() {
 		assert.True(t, block <= 20)
 	}
@@ -373,7 +373,7 @@ func TestLowestIndexedBlockNum(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	lowestBlockIndexed = indexer.BlockNum()
-	assert.Equal(t, uint64(0), lowestBlockIndexed)
+	assert.Equal(t, NoBlockNum, lowestBlockIndexed)
 	blocks := generateIntBlocks()
 	for _, block := range blocks[:50] {
 		err = indexer.Index(context.Background(), block)

--- a/indexer.go
+++ b/indexer.go
@@ -134,16 +134,21 @@ func (i *Indexer[T]) BlockNum() uint64 {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
+	// initialize lowestBlockNum to math.MaxUint64
 	var lowestBlockNum uint64 = math.MaxUint64
 	for _, indexUpdate := range i.indexUpdates {
+		// if no blocks have been indexed, return NoBlockNum
+		if indexUpdate.LastBlockNum == NoBlockNum {
+			return NoBlockNum
+		}
+
+		// update lowestBlockNum if the current indexUpdate has a lower last block number
 		if indexUpdate.LastBlockNum < lowestBlockNum {
 			lowestBlockNum = indexUpdate.LastBlockNum
 		}
 	}
 
-	if lowestBlockNum == math.MaxUint64 {
-		return 0
-	}
+	// return the lowest block number indexed by all indexes
 	return lowestBlockNum
 }
 

--- a/reader.go
+++ b/reader.go
@@ -97,10 +97,11 @@ func NewReader[T any](opt Options) (Reader[T], error) {
 	}
 
 	return &reader[T]{
-		options:   opt,
-		path:      datasetPath,
-		fs:        fs,
-		fileIndex: fileIndex,
+		options:      opt,
+		path:         datasetPath,
+		fs:           fs,
+		fileIndex:    fileIndex,
+		lastBlockNum: uint64(math.MaxUint64),
 	}, nil
 }
 

--- a/writer_no_gap.go
+++ b/writer_no_gap.go
@@ -13,7 +13,7 @@ type noGapWriter[T any] struct {
 }
 
 func NewWriterNoGap[T any](w Writer[T]) Writer[T] {
-	return &noGapWriter[T]{w: w}
+	return &noGapWriter[T]{w: w, lastBlockNum: w.BlockNum()}
 }
 
 func (n *noGapWriter[T]) FileSystem() storage.FS {
@@ -24,7 +24,7 @@ func (n *noGapWriter[T]) Write(ctx context.Context, b Block[T]) error {
 	defer func() { n.lastBlockNum = b.Number }()
 
 	// skip if block number is less than or equal to last block number
-	if b.Number <= n.lastBlockNum {
+	if n.lastBlockNum != NoBlockNum && b.Number <= n.lastBlockNum {
 		return nil
 	}
 
@@ -40,6 +40,7 @@ func (n *noGapWriter[T]) Write(ctx context.Context, b Block[T]) error {
 			return err
 		}
 	}
+
 	return n.w.Write(ctx, b)
 }
 

--- a/writer_with_verify_hash.go
+++ b/writer_with_verify_hash.go
@@ -46,7 +46,7 @@ func NewWriterWithVerifyHash[T any](writer Writer[T], blockHashGetter BlockHashG
 
 func (w *writerWithVerifyHash[T]) Write(ctx context.Context, b Block[T]) error {
 	var err error
-	if w.prevHash == (common.Hash{}) && b.Number > 1 {
+	if w.prevHash == (common.Hash{}) && b.Number > 0 {
 		w.prevHash, err = w.blockHashGetter(ctx, b.Number-1)
 		if err != nil {
 			return fmt.Errorf("failed to get block hash: %w", err)


### PR DESCRIPTION
It turns out that the first block in the blockchain is block 0. Everywhere in our code we assume it's block number 1.

This assumption needs to be changed because otherwise we can not validate the sequential block hash against parent hash.